### PR TITLE
Updated to new go module layout introduced in periph v3.6.7

### DIFF
--- a/max31855.go
+++ b/max31855.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"periph.io/x/periph/conn/physic"
-	"periph.io/x/periph/conn/spi"
+	"periph.io/x/conn/v3/physic"
+	"periph.io/x/conn/v3/spi"
 )
 
 // ErrOpenCircuit - Thermocouple is not connected


### PR DESCRIPTION
Package names have changed to a new layout in v3.6.7 [1]. 

[1] https://periph.io/news/2020/a_new_start/
